### PR TITLE
BuildTemplate[] on intersections

### DIFF
--- a/TemplateOperations/Intersection/Common.wl
+++ b/TemplateOperations/Intersection/Common.wl
@@ -21,7 +21,7 @@ EquationSystem[template1_List,template2_List]:=
 
 ReplacementRules[template1_, template2_, k_Integer:0]:=
   With[{
-      templateVars = SortBy[Union[Flatten[RuleTemplateVars[#] & /@ {template1, template2}, 1]], FromDigits[StringDrop[SymbolName[#],1]]&]
+      templateVars = SortBy[Union[Flatten[RuleTemplateVars[#] & /@ {template1, template2}, 1]], FromDigits[StringDrop[SymbolName[#],1]] &]
     },
     If[k === 0,
       Quiet[Solve[EquationSystem[template1, template2], templateVars]],

--- a/TemplateOperations/Intersection/Kernel/init.m
+++ b/TemplateOperations/Intersection/Kernel/init.m
@@ -1,8 +1,9 @@
 (* ::Package:: *)
 
-Get["CATemplates`TemplateOperations`Intersection`Common`"]
+Get["CATemplates`TemplateOperations`Intersection`Common`"];
 
-Get["CATemplates`TemplateOperations`Intersection`TemplateIntersection`"]
+Get["CATemplates`TemplateOperations`Intersection`TemplateIntersection`"];
 
+Get["CATemplates`TemplateOperations`Intersection`ModularTemplateIntersection`"];
 
-Get["CATemplates`TemplateOperations`Intersection`ModularTemplateIntersection`"]
+Get["CATemplates`TemplateOperations`Intersection`RawIntersection`"];

--- a/TemplateOperations/Intersection/ModularTemplateIntersection.wl
+++ b/TemplateOperations/Intersection/ModularTemplateIntersection.wl
@@ -2,8 +2,9 @@
 
 BeginPackage[
   "CATemplates`TemplateOperations`Intersection`ModularTemplateIntersection`", 
-  { 
-    "CATemplates`Basic`", 
+  {
+    "CATemplates`Basic`",
+    "CATemplates`TemplateGeneration`TemplateFactory`",
     "CATemplates`TemplateOperations`Intersection`Common`"}];
 
 
@@ -13,16 +14,25 @@ ModularTemplateIntersection::usage = "TemplateIntersection[t1_List, t2_List]: Re
 Begin["`Private`"];
 
 
-ModularTemplateIntersection[template1_, template2_, k_] :=
+ModularIntersection[template1_, template2_, k_] :=
   Module[{replacementRules, convertedReplacementRules},
 	replacementRules = ReplacementRules[template1, template2, k];
     If[replacementRules == {}, 
       Return[{}]
     ];
-    (*When a modular template returns 2 different sets of replacement rules, they are both equivalents in terms of ExpandTemplateModK. 
+    (*When a modular template returns 2 different sets of replacement rules, they both have equivalent expansions.
       For that reason, only one of the returned sets is taken into account. *)
     convertedReplacementRules = ConstantsToVariables[First[replacementRules]];
     template1 /. convertedReplacementRules];
+
+ModularTemplateIntersection[template1_Association, template2_Association] :=
+    With[{
+      k = template1[["k"]],
+      r = template1[["r"]],
+      expansion = template1[["expansionFunction"]],
+      rawTemplate1 = template1[["rawList"]],
+      rawTemplate2 = template2[["rawList"]]},
+      BuildTemplate[k, r, ModularIntersection[rawTemplate1, rawTemplate2, k], expansion]];
 
 
 End[];

--- a/TemplateOperations/Intersection/ModularTemplateIntersection.wl
+++ b/TemplateOperations/Intersection/ModularTemplateIntersection.wl
@@ -1,29 +1,28 @@
 (* ::Package:: *)
 
 BeginPackage[
-  "CATemplates`TemplateOperations`Intersection`ModularTemplateIntersection`", 
+  "CATemplates`TemplateOperations`Intersection`ModularTemplateIntersection`",
   {
     "CATemplates`Basic`",
     "CATemplates`TemplateGeneration`TemplateFactory`",
     "CATemplates`TemplateOperations`Intersection`Common`"}];
 
 
-ModularTemplateIntersection::usage = "TemplateIntersection[t1_List, t2_List]: Receives two modular templates t1 and t2, and finds a third template that represents their intersection.";
+ModularTemplateIntersection::usage = "TemplateIntersection[template1_Association, template2_Association]: Receives two modular templates template1 and template2, and finds a third template that represents their intersection.";
 
 
 Begin["`Private`"];
 
-
 ModularIntersection[template1_, template2_, k_] :=
-  Module[{replacementRules, convertedReplacementRules},
-	replacementRules = ReplacementRules[template1, template2, k];
-    If[replacementRules == {}, 
-      Return[{}]
-    ];
-    (*When a modular template returns 2 different sets of replacement rules, they both have equivalent expansions.
+    Module[{replacementRules, convertedReplacementRules},
+      replacementRules = ReplacementRules[template1, template2, k];
+      If[replacementRules == {},
+        Return[{}]
+      ];
+      (*When a modular template returns 2 different sets of replacement rules, they both have equivalent expansions.
       For that reason, only one of the returned sets is taken into account. *)
-    convertedReplacementRules = ConstantsToVariables[First[replacementRules]];
-    template1 /. convertedReplacementRules];
+      convertedReplacementRules = ConstantsToVariables[First[replacementRules]];
+      template1 /. convertedReplacementRules];
 
 ModularTemplateIntersection[template1_Association, template2_Association] :=
     With[{

--- a/TemplateOperations/Intersection/RawIntersection.wl
+++ b/TemplateOperations/Intersection/RawIntersection.wl
@@ -10,6 +10,6 @@ RawIntersection[templateList1_, templateList2_] :=
     With[{replacementRules = ReplacementRules[templateList1, templateList2]},
       If[replacementRules == {},
         {},
-        Union[templateList1 /.replacementRules, templateList2 /. replacementRules]]];
+        First[Union[templateList1 /.replacementRules, templateList2 /. replacementRules]]]];
 
 EndPackage[];

--- a/TemplateOperations/Intersection/RawIntersection.wl
+++ b/TemplateOperations/Intersection/RawIntersection.wl
@@ -1,0 +1,15 @@
+BeginPackage["CATemplates`TemplateOperations`Intersection`RawIntersection`", {"CATemplates`Basic`", "CATemplates`TemplateOperations`Intersection`Common`"}];
+
+RawIntersection::usage= "RawIntersection[t1_List, t2_List]: Receives two templates t1 and t2, and finds a third template that represents their intersection. Both arguments should be raw templates, i.e. templates that don't have special sintax constructs.";
+
+Begin["`Private`"];
+
+End[]; (* `Private` *)
+
+RawIntersection[templateList1_, templateList2_] :=
+    With[{replacementRules = ReplacementRules[templateList1, templateList2]},
+      If[replacementRules == {},
+        {},
+        Union[templateList1 /.replacementRules, templateList2 /. replacementRules]]];
+
+EndPackage[];

--- a/TemplateOperations/Intersection/RestrictedTemplateIntersection.wl
+++ b/TemplateOperations/Intersection/RestrictedTemplateIntersection.wl
@@ -1,0 +1,31 @@
+BeginPackage["CATemplates`TemplateOperations`Intersection`RestrictedTemplateIntersection`", {"CATemplates`Basic`", "CATemplates`TemplateOperations`Intersection`Common`"}];
+
+RestrictedTemplateIntersection::usage="RestrictedTemplateIntersection[rawTemplate1_List, rawTemplate2_List, imprisonmentExpressions_List]: Receives rawTemplate1, rawTemplate2, and a list of imprisonment expressions, and returns the intersection of rawTemplate1 and rawTemplate2 with the corresponding value restrictions taken in account.";
+
+Begin["`Private`"];
+
+VarAssignmentsToImprisonmentExpressions::usage="ToImprisonmentExpression[varAssignments_List]: Receives a list of assignments for a template's variables and returns the equivalent ImprisonmentExpressions."
+VarAssignmentsToImprisonmentExpressions[varAssignments_List] :=
+    #[[1,1]] \[Element] Union[Last /@ #] & /@ Transpose[varAssignments];
+
+
+ImprisonmentExpressionsToReplacementRules::usage = "ImprisonmentExpressionToReplacementRules[imprisonmentExpressions_List]: Takes a list of imprisonment expressions, and returns a list of replacement rules to be applied to a template."
+ImprisonmentExpressionsToReplacementRules[imprisonmentExpressions_List] :=
+    If[Length[#[[2]]] == 1, #[[1]] -> #[[2,1]],#[[1]] -> #]& /@ imprisonmentExpressions;
+
+
+RestrictedTemplateIntersection[rawTemplate1_List, rawTemplate2_List, imprisonmentExpressions_List]:=
+    Module[{rawReplacementRules, valueRestrictions, varAssignments, varReplacementRules},
+      rawReplacementRules = First[ReplacementRules[rawTemplate1, rawTemplate2]];
+      valueRestrictions = (ValueRestrictions /@ imprisonmentExpressions) /. rawReplacementRules;
+      varAssignments = Quiet[Solve[valueRestrictions]];
+      If[rawReplacementRules === {} || varAssignments === {},
+        Return[{}];
+      ];
+      varReplacementRules = ImprisonmentExpressionsToReplacementRules[VarAssignmentsToImprisonmentExpressions[varAssignments]];
+      rawTemplate1 /. rawReplacementRules /. varReplacementRules
+    ];
+
+End[]; (* `Private` *)
+
+EndPackage[];

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -11,26 +11,26 @@ BeginPackage[
   }];
 
 
-TemplateIntersection::usage= "TemplateIntersection[t1_List, t2_List]: Receives two templates t1 and t2, and finds a third template that represents their intersection.";
+TemplateIntersection::usage = "TemplateIntersection[template1_Association, template2_Association]: Receives two templates template1 and template2, and finds a third template that represents their intersection.";
 
 Begin["`Private`"];
 
 TemplateIntersection[template1_Association, template2_Association] :=
-  With[{
-    k = template1[["k"]],
-    r = template1[["r"]],
-    expansion = template1[["expansionFunction"]],
-    rawTemplate1 = RawTemplate[template1[["rawList"]]],
-    rawTemplate2 = RawTemplate[template2[["rawList"]]],
-    imprisonmentExpressions = Join[ImprisonmentExpressions[template1[["rawList"]]], ImprisonmentExpressions[template2[["rawList"]]]]},
-    If[imprisonmentExpressions === {}, 
-      BuildTemplate[k, r, RawIntersection[rawTemplate1, rawTemplate2], expansion],
-      BuildTemplate[k, r, RestrictedTemplateIntersection[rawTemplate1, rawTemplate2, imprisonmentExpressions], expansion]]];
+    With[{
+      k = template1[["k"]],
+      r = template1[["r"]],
+      expansion = template1[["expansionFunction"]],
+      rawTemplate1 = RawTemplate[template1[["rawList"]]],
+      rawTemplate2 = RawTemplate[template2[["rawList"]]],
+      imprisonmentExpressions = Join[ImprisonmentExpressions[template1[["rawList"]]], ImprisonmentExpressions[template2[["rawList"]]]]},
+      If[imprisonmentExpressions === {},
+        BuildTemplate[k, r, RawIntersection[rawTemplate1, rawTemplate2], expansion],
+        BuildTemplate[k, r, RestrictedTemplateIntersection[rawTemplate1, rawTemplate2, imprisonmentExpressions], expansion]]];
 
 
 (* The intersection between two sets of templates is given by the outer product of the intersection over the sets. *)
 TemplateIntersection[x_List, y_List] :=
-  Select[Flatten[TemplateIntersection[#[[1]], #[[2]]] & /@ Flatten[Outer[{#1, #2} &, x, y, 1], 1], 1], (# != {} && ValidTemplateQ[#]) &];
+    Select[Flatten[TemplateIntersection[#[[1]], #[[2]]] & /@ Flatten[Outer[{#1, #2} &, x, y, 1], 1], 1], (# != {} && ValidTemplateQ[#]) &];
 
 
 End[];

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -4,21 +4,15 @@ BeginPackage[
   "CATemplates`TemplateOperations`Intersection`TemplateIntersection`",
   {
     "CATemplates`Basic`", 
-    "CATemplates`TemplateOperations`Intersection`Common`"}];
+    "CATemplates`TemplateOperations`Intersection`Common`",
+    "CATemplates`TemplateOperations`Intersection`RawIntersection`"
+  }];
 
 
 TemplateIntersection::usage= "TemplateIntersection[t1_List, t2_List]: Receives two templates t1 and t2, and finds a third template that represents their intersection.";
 
 
 Begin["`Private`"];
-
-
-RawTemplateIntersection::usage= "RawTemplateIntersection[t1_List, t2_List]: Receives two templates t1 and t2, and finds a third template that represents their intersection. Both arguments should be raw templates, i.e. templates that don't have special sintax constructs.";
-RawTemplateIntersection[template1_, template2_] :=
-  With[{replacementRules = ReplacementRules[template1, template2]},
-    If[replacementRules == {},
-      {},
-      Union[template1 /.replacementRules, template2 /. replacementRules]]];
 
 
 VarAssignmentsToImprisonmentExpressions::usage="ToImprisonmentExpression[varAssignments_List]: Receives a list of assignments for a template's variables and returns the equivalent ImprisonmentExpressions."
@@ -41,7 +35,7 @@ RestrictedTemplateIntersection[rawTemplate1_List, rawTemplate2_List, imprisonmen
       Return[{}];
     ];
     varReplacementRules = ImprisonmentExpressionsToReplacementRules[VarAssignmentsToImprisonmentExpressions[varAssignments]];
-	rawTemplate1 /. rawReplacementRules /. varReplacementRules
+	  rawTemplate1 /. rawReplacementRules /. varReplacementRules
  ]
 
 
@@ -51,7 +45,7 @@ TemplateIntersection[template1_, template2_] :=
     rawTemplate2 = RawTemplate[template2],
     imprisonmentExpressions = Join[ImprisonmentExpressions[template1], ImprisonmentExpressions[template2]]},
     If[imprisonmentExpressions === {}, 
-      RawTemplateIntersection[rawTemplate1, rawTemplate2],
+      RawIntersection[rawTemplate1, rawTemplate2],
       RestrictedTemplateIntersection[rawTemplate1, rawTemplate2, imprisonmentExpressions]]];
 
 

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -5,39 +5,14 @@ BeginPackage[
   {
     "CATemplates`Basic`", 
     "CATemplates`TemplateOperations`Intersection`Common`",
-    "CATemplates`TemplateOperations`Intersection`RawIntersection`"
+    "CATemplates`TemplateOperations`Intersection`RawIntersection`",
+    "CATemplates`TemplateOperations`Intersection`RestrictedTemplateIntersection`"
   }];
 
 
 TemplateIntersection::usage= "TemplateIntersection[t1_List, t2_List]: Receives two templates t1 and t2, and finds a third template that represents their intersection.";
 
-
 Begin["`Private`"];
-
-
-VarAssignmentsToImprisonmentExpressions::usage="ToImprisonmentExpression[varAssignments_List]: Receives a list of assignments for a template's variables and returns the equivalent ImprisonmentExpressions."
-VarAssignmentsToImprisonmentExpressions[varAssignments_List] :=
-  #[[1,1]] \[Element] Union[Last /@ #] & /@ Transpose[varAssignments];
-
-
-ImprisonmentExpressionsToReplacementRules::usage = "ImprisonmentExpressionToReplacementRules[imprisonmentExpressions_List]: Takes a list of imprisonment expressions, and returns a list of replacement rules to be applied to a template."
-ImprisonmentExpressionsToReplacementRules[imprisonmentExpressions_List] :=
-  If[Length[#[[2]]] == 1, #[[1]] -> #[[2,1]],#[[1]] -> #]& /@ imprisonmentExpressions;
-
-
-RestrictedTemplateIntersection::usage="RestrictedTemplateIntersection[rawTemplate1_List, rawTemplate2_List, imprisonmentExpressions_List]: Receives rawTemplate1, rawTemplate2, and a list of imprisonment expressions, and returns the intersection of rawTemplate1 and rawTemplate2 with the corresponding value restrictions taken in account."
-RestrictedTemplateIntersection[rawTemplate1_List, rawTemplate2_List, imprisonmentExpressions_List]:=
-  Module[{rawReplacementRules, valueRestrictions, varAssignments, varReplacementRules},
-    rawReplacementRules = First[ReplacementRules[rawTemplate1, rawTemplate2]];
-    valueRestrictions = (ValueRestrictions /@ imprisonmentExpressions) /. rawReplacementRules;
-    varAssignments = Quiet[Solve[valueRestrictions]];
-    If[rawReplacementRules === {} || varAssignments === {},
-      Return[{}];
-    ];
-    varReplacementRules = ImprisonmentExpressionsToReplacementRules[VarAssignmentsToImprisonmentExpressions[varAssignments]];
-	  rawTemplate1 /. rawReplacementRules /. varReplacementRules
- ]
-
 
 TemplateIntersection[template1_, template2_] :=
   With[{

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -3,7 +3,8 @@
 BeginPackage[
   "CATemplates`TemplateOperations`Intersection`TemplateIntersection`",
   {
-    "CATemplates`Basic`", 
+    "CATemplates`Basic`",
+    "CATemplates`TemplateGeneration`TemplateFactory`",
     "CATemplates`TemplateOperations`Intersection`Common`",
     "CATemplates`TemplateOperations`Intersection`RawIntersection`",
     "CATemplates`TemplateOperations`Intersection`RestrictedTemplateIntersection`"
@@ -14,18 +15,21 @@ TemplateIntersection::usage= "TemplateIntersection[t1_List, t2_List]: Receives t
 
 Begin["`Private`"];
 
-TemplateIntersection[template1_, template2_] :=
+TemplateIntersection[template1_Association, template2_Association] :=
   With[{
-    rawTemplate1 = RawTemplate[template1],
-    rawTemplate2 = RawTemplate[template2],
-    imprisonmentExpressions = Join[ImprisonmentExpressions[template1], ImprisonmentExpressions[template2]]},
+    k = template1[["k"]],
+    r = template1[["r"]],
+    expansion = template1[["expansionFunction"]],
+    rawTemplate1 = RawTemplate[template1[["rawList"]]],
+    rawTemplate2 = RawTemplate[template2[["rawList"]]],
+    imprisonmentExpressions = Join[ImprisonmentExpressions[template1[["rawList"]]], ImprisonmentExpressions[template2[["rawList"]]]]},
     If[imprisonmentExpressions === {}, 
-      RawIntersection[rawTemplate1, rawTemplate2],
-      RestrictedTemplateIntersection[rawTemplate1, rawTemplate2, imprisonmentExpressions]]];
+      BuildTemplate[k, r, RawIntersection[rawTemplate1, rawTemplate2], expansion],
+      BuildTemplate[k, r, RestrictedTemplateIntersection[rawTemplate1, rawTemplate2, imprisonmentExpressions], expansion]]];
 
 
 (* The intersection between two sets of templates is given by the outer product of the intersection over the sets. *)
-TemplateIntersection[x_ /; MatchQ[x, {{__} ..}], y_ /; MatchQ[y, {{__} ..}]] :=
+TemplateIntersection[x_List, y_List] :=
   Select[Flatten[TemplateIntersection[#[[1]], #[[2]]] & /@ Flatten[Outer[{#1, #2} &, x, y, 1], 1], 1], (# != {} && ValidTemplateQ[#]) &];
 
 

--- a/Tests/TemplateOperations/Intersection/ModularTemplateIntersection.m
+++ b/Tests/TemplateOperations/Intersection/ModularTemplateIntersection.m
@@ -1,28 +1,44 @@
 (* ::Package:: *)
 
-<<CATemplates`
+<<CATemplates`;
 
+report = TestReport[
+  {
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[3, 1.0, {x1, x0}, RawExpansion]},
+        TemplateIntersection[t1, t1] === t1]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[3, 1.0, {x1, x0}, RawExpansion],
+        t2 = BuildTemplate[3, 1.0, {1, x0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === t2]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[3, 1.0, {x2, 1, x0}, RawExpansion],
+        t2 = BuildTemplate[3, 1.0, {x2, x1, x0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === t1]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[3, 1.0, {x1, x0}, RawExpansion],
+        t2 = BuildTemplate[3, 1.0, {1, x0}, RawExpansion],
+        t3 = BuildTemplate[3, 1.0, {0, x0}, RawExpansion]},
+        With[{i1 = ModularTemplateIntersection[t1, t2],
+          i2 = ModularTemplateIntersection[t1, t3],
+          result = BuildTemplate[3, 1.0, {}, RawExpansion]},
+          ModularTemplateIntersection[i1, i2] === result]]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[3, 1.0, {x1, x0}, RawExpansion],
+        t2 = BuildTemplate[3, 1.0, {1, x0}, RawExpansion],
+        t3 = BuildTemplate[3, 1.0, {x1, 0}, RawExpansion]},
+        With[{
+          i1 = ModularTemplateIntersection[t1, t2],
+          i2 = ModularTemplateIntersection[t1, t3],
+          result = BuildTemplate[3, 1.0, {1, 0}, RawExpansion]},
+          ModularTemplateIntersection[i1, i2] === result]]]
+  }
+];
 
-Print[ModularTemplateIntersection[{x1, x0}, {x1, x0}, 3] === {x1, x0}]
-
-
-Print[ModularTemplateIntersection[{x1, x0}, {1, x0}, 3] === {1, x0}]
-
-
-Print[ModularTemplateIntersection[{x2, x1, x0}, {x2, 1, x0}, 3] === {x2, 1, x0}]
-
-
-Print[
-With[
- {i1 = ModularTemplateIntersection[{x1, x0}, {1, x0}, 3],
-  i2 = ModularTemplateIntersection[{x1, x0}, {0, x0}, 3]},
- ModularTemplateIntersection[i1, i2, 3] === {}]
-]
-
-
-Print[
-With[
- {i1 = ModularTemplateIntersection[{x1, x0}, {1, x0}, 3],
-  i2 = {x1, 0}},
- ModularTemplateIntersection[i1, i2, 3] === {1, 0}]
-]
+Print["Suceeded: " <> ToString[report["TestsSucceededCount"]]];
+Print["Failed: " <> ToString[report["TestsFailedCount"]]];

--- a/Tests/TemplateOperations/Intersection/ModularTemplateIntersection.m
+++ b/Tests/TemplateOperations/Intersection/ModularTemplateIntersection.m
@@ -7,17 +7,17 @@ report = TestReport[
     VerificationTest[
       With[{
         t1 = BuildTemplate[3, 1.0, {x1, x0}, RawExpansion]},
-        TemplateIntersection[t1, t1] === t1]],
+        ModularTemplateIntersection[t1, t1] === t1]],
     VerificationTest[
       With[{
         t1 = BuildTemplate[3, 1.0, {x1, x0}, RawExpansion],
         t2 = BuildTemplate[3, 1.0, {1, x0}, RawExpansion]},
-        TemplateIntersection[t1, t2] === t2]],
+        ModularTemplateIntersection[t1, t2] === t2]],
     VerificationTest[
       With[{
         t1 = BuildTemplate[3, 1.0, {x2, 1, x0}, RawExpansion],
         t2 = BuildTemplate[3, 1.0, {x2, x1, x0}, RawExpansion]},
-        TemplateIntersection[t1, t2] === t1]],
+        ModularTemplateIntersection[t1, t2] === t1]],
     VerificationTest[
       With[{
         t1 = BuildTemplate[3, 1.0, {x1, x0}, RawExpansion],

--- a/Tests/TemplateOperations/Intersection/RawIntersection.m
+++ b/Tests/TemplateOperations/Intersection/RawIntersection.m
@@ -6,42 +6,42 @@ report = TestReport[
       With[{
         t1 = OldBaseTemplate[],
         t2 = ConstantArray[0, 8]},
-        RawIntersection[t1, t2] === {t2}]],
+        RawIntersection[t1, t2] === t2]],
     VerificationTest[
       With[{
         t1 = OldBaseTemplate[],
         t2 = ConstantArray[1, 8]},
-        RawIntersection[t1, t2] === {t2}]],
+        RawIntersection[t1, t2] === t2]],
     VerificationTest[
       With[{
         t1 = OldBaseTemplate[]},
-        RawIntersection[t1, t1] === {t1}]],
+        RawIntersection[t1, t1] === t1]],
     VerificationTest[
       With[{
         t1 = OldBaseTemplate[2, 2]},
-        RawIntersection[t1, t1] === {t1}]],
+        RawIntersection[t1, t1] === t1]],
     VerificationTest[
       With[{
         t1 = OldBaseTemplate[2, 3]},
-        RawIntersection[t1, t1] === {t1}]],
+        RawIntersection[t1, t1] === t1]],
     VerificationTest[
       With[{
         t1 = {x7, 0, x5, 0, x3, 0, x1, 0},
         t2 = {x7, 0, x5, 0, x3, 0, x1, 0},
         result = {x7, 0, x5, 0, x3, 0, x1, 0}},
-        RawIntersection[t1, t2] === {result}]],
+        RawIntersection[t1, t2] === result]],
     VerificationTest[
       With[{
         t1 = OldBaseTemplate[],
         t2 = {x7, 0, x5, 0, x3, 0, x1, 0},
         result = {x7, 0, x5, 0, x3, 0, x1, 0}},
-        RawIntersection[t1, t2] === {result}]],
+        RawIntersection[t1, t2] === result]],
     VerificationTest[
       With[{
         t1 = {x7, 0, x5, 0, x3, 0, x1, 0},
         t2 = OldBaseTemplate[],
         result = {x7, 0, x5, 0, x3, 0, x1, 0}},
-        RawIntersection[t1, t2] === {result}]]
+        RawIntersection[t1, t2] === result]]
   }];
 
 Print["Suceeded: " <> ToString[report["TestsSucceededCount"]]];

--- a/Tests/TemplateOperations/Intersection/RawIntersection.m
+++ b/Tests/TemplateOperations/Intersection/RawIntersection.m
@@ -1,0 +1,48 @@
+<< CATemplates`
+
+report = TestReport[
+  {
+    VerificationTest[
+      With[{
+        t1 = OldBaseTemplate[],
+        t2 = ConstantArray[0, 8]},
+        RawIntersection[t1, t2] === {t2}]],
+    VerificationTest[
+      With[{
+        t1 = OldBaseTemplate[],
+        t2 = ConstantArray[1, 8]},
+        RawIntersection[t1, t2] === {t2}]],
+    VerificationTest[
+      With[{
+        t1 = OldBaseTemplate[]},
+        RawIntersection[t1, t1] === {t1}]],
+    VerificationTest[
+      With[{
+        t1 = OldBaseTemplate[2, 2]},
+        RawIntersection[t1, t1] === {t1}]],
+    VerificationTest[
+      With[{
+        t1 = OldBaseTemplate[2, 3]},
+        RawIntersection[t1, t1] === {t1}]],
+    VerificationTest[
+      With[{
+        t1 = {x7, 0, x5, 0, x3, 0, x1, 0},
+        t2 = {x7, 0, x5, 0, x3, 0, x1, 0},
+        result = {x7, 0, x5, 0, x3, 0, x1, 0}},
+        RawIntersection[t1, t2] === {result}]],
+    VerificationTest[
+      With[{
+        t1 = OldBaseTemplate[],
+        t2 = {x7, 0, x5, 0, x3, 0, x1, 0},
+        result = {x7, 0, x5, 0, x3, 0, x1, 0}},
+        RawIntersection[t1, t2] === {result}]],
+    VerificationTest[
+      With[{
+        t1 = {x7, 0, x5, 0, x3, 0, x1, 0},
+        t2 = OldBaseTemplate[],
+        result = {x7, 0, x5, 0, x3, 0, x1, 0}},
+        RawIntersection[t1, t2] === {result}]]
+  }];
+
+Print["Suceeded: " <> ToString[report["TestsSucceededCount"]]];
+Print["Failed: " <> ToString[report["TestsFailedCount"]]];

--- a/Tests/TemplateOperations/Intersection/RestrictedTemplateIntersection.m
+++ b/Tests/TemplateOperations/Intersection/RestrictedTemplateIntersection.m
@@ -1,0 +1,62 @@
+<< CATemplates`;
+
+report = TestReport[{
+  VerificationTest[
+    With[{
+      t1 = {x2, x1, x0},
+      t2 = {x2, x0, x0},
+      restrictions = {x2 \[Element] {0, 2}},
+      result = {x2 \[Element] {0, 2}, x0, x0}},
+      RestrictedTemplateIntersection[t1, t2, restrictions] === result]],
+  VerificationTest[
+    With[{
+      t1 = {x2, x1, x0},
+      t2 = {x2, x0, x0},
+      restrictions = {x2 \[Element] {0, 2}, x2 \[Element] {0, 1}},
+      result = {0, x0, x0}},
+      RestrictedTemplateIntersection[t1, t2, restrictions] === result]],
+  VerificationTest[
+    With[{
+      t1 = {x2, x1, x0},
+      t2 = {x2, x0, x0},
+      restrictions = {x1 \[Element] {0, 2}, x2 \[Element] {0, 1}},
+      result = {x2 \[Element] {0, 1}, x0 \[Element] {0, 2}, x0 \[Element] {0, 2}}},
+      RestrictedTemplateIntersection[t1, t2, restrictions] === result]],
+  VerificationTest[
+    With[{
+      t1 = {x2, x1, x0},
+      t2 = {0, x0, x0},
+      restrictions = {x2 \[Element] {0, 2}},
+      result = {0, x0, x0}},
+      RestrictedTemplateIntersection[t1, t2, restrictions] === result]],
+  VerificationTest[
+    With[{
+      t1 = {x2, x1, x0},
+      t2 = {2, x0, x0},
+      restrictions = {x2 \[Element] {2}},
+      result = {2, x0, x0}},
+      RestrictedTemplateIntersection[t1, t2, restrictions] === result]],
+  VerificationTest[
+    With[{
+      t1 = {x2, x1, x0},
+      t2 = {0, x0, x0},
+      restrictions = {x2 \[Element] {2}}},
+      RestrictedTemplateIntersection[t1, t2, restrictions] === {}]],
+  VerificationTest[
+    With[{
+      t1 = {x2, x1, x0},
+      t2 = {x2, x0, x0},
+      restrictions = {x2 \[Element] {2, 3}, x2 \[Element] {1, 2, 3}},
+      result = {x2 \[Element] {2, 3}, x0, x0}},
+      RestrictedTemplateIntersection[t1, t2, restrictions] === result]],
+  VerificationTest[
+    With[{
+      t1 = {x2, x1, x0},
+      t2 = {x2, x0, x0},
+      restrictions = {x2 \[Element] {0, 2}, x1 \[Element] {0, 1}, x2 \[Element] {0, 1}, x0 \[Element] {1, 2}},
+      result = {x2 \[Element] {2, 3}, x0, x0}},
+      RestrictedTemplateIntersection[t1, t2, restrictions] === {0, 1, 1}]]
+}];
+
+Print["Suceeded: " <> ToString[report["TestsSucceededCount"]]];
+Print["Failed: " <> ToString[report["TestsFailedCount"]]];

--- a/Tests/TemplateOperations/Intersection/TemplateIntersection.m
+++ b/Tests/TemplateOperations/Intersection/TemplateIntersection.m
@@ -1,63 +1,98 @@
 (* ::Package:: *)
 
-<< CATemplates`
+<< CATemplates`;
 
+report = TestReport[
+  {
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, OldBaseTemplate[], RawExpansion],
+        t2 = BuildTemplate[2,1.0, ConstantArray[0, 8], RawExpansion]},
+        TemplateIntersection[t1, t2] === t2]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, OldBaseTemplate[], RawExpansion],
+        t2 = BuildTemplate[2,1.0, ConstantArray[1, 8], RawExpansion]},
+        TemplateIntersection[t1, t2] === t2]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, OldBaseTemplate[], RawExpansion]},
+        TemplateIntersection[t1, t1] === t1]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, OldBaseTemplate[2, 2], RawExpansion]},
+        TemplateIntersection[t1, t1] === t1]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, OldBaseTemplate[2, 3], RawExpansion]},
+        TemplateIntersection[t1, t1] === t1]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2, 1.0, {x7, 0, x5, 0, x3, 0, x1, 0}, RawExpansion],
+        t2 = BuildTemplate[2, 1.0, {x7, 0, x5, 0, x3, 0, x1, 0}, RawExpansion],
+        result = BuildTemplate[2, 1.0, {x7, 0, x5, 0, x3, 0, x1, 0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, OldBaseTemplate[], RawExpansion],
+        t2 = BuildTemplate[2,1.0, {x7, 0, x5, 0, x3, 0, x1, 0}, RawExpansion],
+        result = BuildTemplate[2,1.0, {x7, 0, x5, 0, x3, 0, x1, 0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, {x7, 0, x5, 0, x3, 0, x1, 0}, RawExpansion],
+        t2 = BuildTemplate[2,1.0, OldBaseTemplate[], RawExpansion],
+        result = BuildTemplate[2,1.0, {x7, 0, x5, 0, x3, 0, x1, 0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, {x2 \[Element] {0, 2}, x1, x0}, RawExpansion],
+        t2 = BuildTemplate[2,1.0, {x2, x0, x0}, RawExpansion],
+        result = BuildTemplate[2,1.0, {x2 \[Element] {0, 2}, x0, x0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, {x2 \[Element] {0, 2}, x1, x0}, RawExpansion],
+        t2 = BuildTemplate[2,1.0, {x2 \[Element] {0, 1}, x0, x0}, RawExpansion],
+        result = BuildTemplate[2,1.0, {0, x0, x0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, {x2, x1 \[Element] {0, 2}, x0}, RawExpansion],
+        t2 = BuildTemplate[2,1.0, {x2 \[Element] {0, 1}, x0, x0}, RawExpansion],
+        result = BuildTemplate[2,1.0, {x2 \[Element] {0, 1}, x0 \[Element] {0, 2}, x0 \[Element] {0, 2}}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, {x2 \[Element] {0, 2}, x1, x0}, RawExpansion],
+        t2 = BuildTemplate[2,1.0, {0, x0, x0}, RawExpansion],
+        result = BuildTemplate[2,1.0, {0, x0, x0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, {x2 \[Element] {2}, x1, x0}, RawExpansion],
+        t2 = BuildTemplate[2,1.0, {2, x0, x0}, RawExpansion],
+        result = BuildTemplate[2,1.0, {2, x0, x0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, {x2 \[Element] {2}, x1, x0}, RawExpansion],
+        t2 = BuildTemplate[2,1.0, {0, x0, x0}, RawExpansion],
+        result = BuildTemplate[2,1.0, {}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, {x2 \[Element] {2, 3}, x1, x0}, RawExpansion],
+        t2 = BuildTemplate[2,1.0, {x2 \[Element] {1, 2, 3}, x0, x0}, RawExpansion],
+        result = BuildTemplate[2,1.0, {x2 \[Element] {2, 3}, x0, x0}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]],
+    VerificationTest[
+      With[{
+        t1 = BuildTemplate[2,1.0, {x2 \[Element] {0, 2}, x1 \[Element] {0, 1}, x0}, RawExpansion],
+        t2 = BuildTemplate[2,1.0, {x2  \[Element] {0, 1}, x0 \[Element] {1, 2}, x0}, RawExpansion],
+        result = BuildTemplate[2,1.0, {0, 1, 1}, RawExpansion]},
+        TemplateIntersection[t1, t2] === result]]
+  }];
 
-Print["Raw Intersection"]
-
-
-Print[TemplateIntersection[ConstantArray[0, 8], ConstantArray[1, 8]] === {}]
-
-
-Print[TemplateIntersection[{x8, 0, x6, 0, x4, 0, x2, 0}, {x8, 0, x6, 0, x4, 0, x2, 0}] === {{x8, 0, x6, 0, x4, 0, x2, 0}}]
-
-
-Print[TemplateIntersection[OldBaseTemplate[], OldBaseTemplate[]] === {OldBaseTemplate[]}]
-
-
-Print[TemplateIntersection[OldBaseTemplate[2, 2], OldBaseTemplate[2, 2]] === {OldBaseTemplate[2, 2]}]
-
-
-Print[TemplateIntersection[OldBaseTemplate[2, 3], OldBaseTemplate[2, 3]] === {OldBaseTemplate[2, 3]}]
-
-
-Print[TemplateIntersection[OldBaseTemplate[], ConstantArray[0, 8]] === {ConstantArray[0, 8]}]
-
-
-Print[TemplateIntersection[OldBaseTemplate[], ConstantArray[1, 8]] === {ConstantArray[1, 8]}]
-
-
-Print[TemplateIntersection[OldBaseTemplate[], {x7, 0, x5, 0, x3, 0, x1, 0}] === {{x7, 0, x5, 0, x3, 0, x1, 0}}]
-
-
-Print[TemplateIntersection[{x7, 0, x5, 0, x3, 0, x1, 0}, OldBaseTemplate[]] === {{x7, 0, x5, 0, x3, 0, x1, 0}}]
-
-
-Print["Variable Constraint Intersection"]
-
-
-Print[TemplateIntersection[{x2 \[Element] {0, 2}, x1, x0}, {x2 \[Element] {0, 2}, x0, x0}] === {x2 \[Element] {0, 2}, x0, x0}]
-
-
-Print[TemplateIntersection[{x2, x1, x0}, {x2 \[Element] {0, 2}, x0, x0}] === {x2 \[Element] {0, 2}, x0, x0}]
-
-
-Print[TemplateIntersection[{x2 \[Element] {0, 2}, x1, x0}, {x2 \[Element] {0, 1}, x0, x0}] === {0, x0, x0}]
-
-
-Print[TemplateIntersection[{x2, x1 \[Element] {0, 2}, x0}, {x2 \[Element] {0, 1}, x0, x0}] === {x2 \[Element] {0, 1}, x0 \[Element] {0, 2}, x0 \[Element] {0, 2}}]
-
-
-Print[TemplateIntersection[{x2 \[Element] {0, 2}, x1, x0}, {0, x0, x0}] === {0, x0, x0}]
-
-
-Print[TemplateIntersection[{x2 \[Element] {2}, x1, x0}, {2, x0, x0}] === {2, x0, x0}]
-
-
-Print[TemplateIntersection[{x2 \[Element] {2}, x1, x0}, {0, x0, x0}] === {}]
-
-
-Print[TemplateIntersection[{x2 \[Element] {2, 3}, x1, x0}, {x2 \[Element] {1, 2, 3}, x0, x0}] === {x2 \[Element] {2, 3}, x0, x0}]
-
-
-Print[TemplateIntersection[{x2 \[Element] {0, 2}, x1 \[Element] {0, 1}, x0}, {x2 \[Element] {0, 1}, x0 \[Element] {1, 2}, x0}] === {0, 1, 1}]
+Print["Suceeded: " <> ToString[report["TestsSucceededCount"]]];
+Print["Failed: " <> ToString[report["TestsFailedCount"]]];


### PR DESCRIPTION
Both `TemplateIntersection`  and `ModularTemplateIntersection` now accept Template associations as arguments and return their results accordingly.

This PR breaks `ColorBlindTemplate[]` (to be fixed in a near future PR).
