### PR TITLE
Fix intersection

### DIFF
--- a/Basic.wl
+++ b/Basic.wl
@@ -10,7 +10,6 @@ PrintTestResults::usage = "PrintTestResults[testReport_] := Prints the results o
 SubstitutionRange::usage = "SubstitutionRange[template_Association] := Gives a range from 0 to the maximum possible substitution the template could have";
 
 OldBaseTemplate::usage = "Gives the base template for a radius r k-ary rule.";
-RuleTemplateVars::usage = "Extracts the variable names used in a rule template and returns them in a list. The names are given in lexicographical order; for instance, RuleTemplateVars[MaxSymmTemplate[{BWLR, BW, LR}, 2, 1]] returns {x2, x1, x0}. If the template is in the k-ary form, the function returns {}.";
 TakeNeighbourhoods::usage = "Returns the n first neighborhoods from a given space.";
 TemplateFromNeighbourhoods::usage = "Builds a template given a list of neighbourhoods. Converts the neighbourhoods to symbols in the form xN, where N is the decimal conversion of the k-ary neighbourhood.";
 TemplateVarFromNeighbourhood::usage = "Returns the template symbol orresponding to a given neighbourhood";
@@ -59,10 +58,11 @@ Partial[f_, as__] := Function[Null, f[as, ##], HoldAll];
 OldBaseTemplate[k_Integer: 2, r_: 1] :=
   Symbol["x" <> ToString[#]] & /@ Range[(\!\(\*SuperscriptBox[\(k\), \(\[LeftCeiling]r*2\[RightCeiling] + 1\)]\)) - 1, 0, -1];
 
+(*Deprecated!!*)
 RuleTemplateVars[ruletemplate_Association] :=
     RuleTemplateVars[ruletemplate[["rawList"]]];
-
-RuleTemplateVars[ruletemplate_] := 
+(*Deprecated!!*)
+RuleTemplateVars[ruletemplate_] :=
   SortBy[Union[Cases[ruletemplate, _Symbol, Infinity]], FromDigits[StringDrop[SymbolName[#],1]]&]
 
 TakeNeighbourhoods[n_Integer, k_Integer: 2, r_Integer: 1] :=

--- a/Basic.wl
+++ b/Basic.wl
@@ -10,7 +10,6 @@ PrintTestResults::usage = "PrintTestResults[testReport_] := Prints the results o
 SubstitutionRange::usage = "SubstitutionRange[template_Association] := Gives a range from 0 to the maximum possible substitution the template could have";
 
 OldBaseTemplate::usage = "Gives the base template for a radius r k-ary rule.";
-ValidTemplateQ::usage = "Determines if a template has avalid form.";
 RuleTemplateVars::usage = "Extracts the variable names used in a rule template and returns them in a list. The names are given in lexicographical order; for instance, RuleTemplateVars[MaxSymmTemplate[{BWLR, BW, LR}, 2, 1]] returns {x2, x1, x0}. If the template is in the k-ary form, the function returns {}.";
 TakeNeighbourhoods::usage = "Returns the n first neighborhoods from a given space.";
 TemplateFromNeighbourhoods::usage = "Builds a template given a list of neighbourhoods. Converts the neighbourhoods to symbols in the form xN, where N is the decimal conversion of the k-ary neighbourhood.";
@@ -59,9 +58,6 @@ Partial[f_, as__] := Function[Null, f[as, ##], HoldAll];
 
 OldBaseTemplate[k_Integer: 2, r_: 1] :=
   Symbol["x" <> ToString[#]] & /@ Range[(\!\(\*SuperscriptBox[\(k\), \(\[LeftCeiling]r*2\[RightCeiling] + 1\)]\)) - 1, 0, -1];
-
-ValidTemplateQ[template_] :=
-  And @@ (MatchQ[#, (_Symbol | _Integer | _Plus | _Times | _ \[Element] {__})] & /@ template);
 
 RuleTemplateVars[ruletemplate_Association] :=
     RuleTemplateVars[ruletemplate[["rawList"]]];

--- a/Basic.wl
+++ b/Basic.wl
@@ -60,7 +60,7 @@ OldBaseTemplate[k_Integer: 2, r_: 1] :=
 
 (*Deprecated!!*)
 RuleTemplateVars[ruletemplate_Association] :=
-    RuleTemplateVars[ruletemplate[["rawList"]]];
+    RuleTemplateVars[ruletemplate[["core"]]];
 (*Deprecated!!*)
 RuleTemplateVars[ruletemplate_] :=
   SortBy[Union[Cases[ruletemplate, _Symbol, Infinity]], FromDigits[StringDrop[SymbolName[#],1]]&]

--- a/CATemplate.wl
+++ b/CATemplate.wl
@@ -11,6 +11,8 @@ BaseTemplate::usage="BaseTemplate[k_Integer, r_Real] := Gives the base template 
 
 ValidTemplateCoreQ::usage = "Determines if a template core has a valid sintax.";
 
+TemplateCoreVars::usage = "TemplateCoreVars[templateCore_List] := Gives all variables from a templateCore.";
+
 k::usage="k[t_] = Gets the number of possible states (k) for cells of the space represented by template t.";
 
 r::usage="r[t_] = Gets the radius (r) of the family represented by template t.";
@@ -46,6 +48,15 @@ ValidTemplateCoreQ[templateCore_] :=
     And @@ (MatchQ[#, (_Symbol | _Integer | _Plus | _Times | _ \[Element] {__})] & /@ templateCore);
 
 (* Accessor functions *)
+
+TemplateCoreVars[template_Association] :=
+    TemplateCoreVars[kAryRuleTemplate[template]];
+
+TemplateCoreVars[templateCore_List] :=
+    With[{
+      symbols = Union[Cases[templateCore, _Symbol, Infinity]],
+      byIndex = FromDigits[StringDrop[SymbolName[#],1]] &},
+      SortBy[symbols, byIndex]];
 
 k[t_Association] := t[["k"]];
 

--- a/CATemplate.wl
+++ b/CATemplate.wl
@@ -9,6 +9,8 @@ BuildTemplate[k_Integer, r_Real, rawList_List, expansion_Function, N_Integer]
 
 BaseTemplate::usage="BaseTemplate[k_Integer, r_Real] := Gives the base template for the space of radius r k-ary rules.";
 
+ValidTemplateCoreQ::usage = "Determines if a template core has a valid sintax.";
+
 k::usage="k[t_] = Gets the number of possible states (k) for cells of the space represented by template t.";
 
 r::usage="r[t_] = Gets the radius (r) of the family represented by template t.";
@@ -23,6 +25,8 @@ templateMod::usage="templateMod[t_] = Gets a templateMod number used by template
 
 Begin["`Private`"];
 
+(* Builder functions *)
+
 BuildTemplate[k_Integer, r_Real, rawList_List] :=
     Association["k" -> k, "r" -> r, "rawList" -> rawList, "postExpansionFn" -> IdentityFn];
 
@@ -35,6 +39,13 @@ BuildTemplate[k_Integer, r_Real, rawList_List, postExpansionFn_, N_Integer] :=
 BaseTemplate[k_Integer, r_Real] :=
     With[{list = Symbol["x" <> ToString[#]] & /@ Range[(k^(Ceiling[r * 2] + 1)) -1, 0, -1]},
       BuildTemplate[k, r, list]];
+
+(* Validators *)
+
+ValidTemplateCoreQ[templateCore_] :=
+    And @@ (MatchQ[#, (_Symbol | _Integer | _Plus | _Times | _ \[Element] {__})] & /@ templateCore);
+
+(* Accessor functions *)
 
 k[t_Association] := t[["k"]];
 

--- a/CATemplate.wl
+++ b/CATemplate.wl
@@ -1,11 +1,11 @@
 BeginPackage["CATemplates`CATemplate`", {"CATemplates`TemplateOperations`Expansion`PostExpansionFn`IdentityFn`"}];
 
 BuildTemplate::usage=
-    "BuildTemplate[k_Integer, r_Real, rawList_List, expansion_Function]
-  Builds a template that represents the subspace of the CA space given by k and r, described by the variables in <rawList>.
+    "BuildTemplate[k_Integer, r_Real, core_List, expansion_Function]
+  Builds a template that represents the subspace of the CA space given by k and r, described by the variables in <core>.
   <expansion> is the function used by ExpandTemplate to expand the built template.
-BuildTemplate[k_Integer, r_Real, rawList_List, expansion_Function, N_Integer]
-  <N> is the value of modulus used by the template generator to create <rawList>.";
+BuildTemplate[k_Integer, r_Real, core_List, expansion_Function, N_Integer]
+  <N> is the value of modulus used by the template generator to create <core>.";
 
 BaseTemplate::usage="BaseTemplate[k_Integer, r_Real] := Gives the base template for the space of radius r k-ary rules.";
 
@@ -17,7 +17,7 @@ k::usage="k[t_] = Gets the number of possible states (k) for cells of the space 
 
 r::usage="r[t_] = Gets the radius (r) of the family represented by template t.";
 
-kAryRuleTemplate::usage="kAryRuleTemplate[t_] = Gets the kAryRuleTemplate which represents a subset of the base t (including template variables).";
+templateCore::usage="templateCore[t_] = Gets the core of template t (list of variables + fixed positions).";
 
 expansionFunction::usage="expansionFunction[t_] = Gets the expansion function used by template t.";
 
@@ -29,14 +29,14 @@ Begin["`Private`"];
 
 (* Builder functions *)
 
-BuildTemplate[k_Integer, r_Real, rawList_List] :=
-    Association["k" -> k, "r" -> r, "rawList" -> rawList, "postExpansionFn" -> IdentityFn];
+BuildTemplate[k_Integer, r_Real, core_List] :=
+    Association["k" -> k, "r" -> r, "core" -> core, "postExpansionFn" -> IdentityFn];
 
-BuildTemplate[k_Integer, r_Real, rawList_List, postExpansionFn_] :=
-    Association["k" -> k, "r" -> r, "rawList" -> rawList, "postExpansionFn" -> postExpansionFn];
+BuildTemplate[k_Integer, r_Real, core_List, postExpansionFn_] :=
+    Association["k" -> k, "r" -> r, "core" -> core, "postExpansionFn" -> postExpansionFn];
 
-BuildTemplate[k_Integer, r_Real, rawList_List, postExpansionFn_, N_Integer] :=
-    Association["k" -> k, "r" -> r, "rawList" -> rawList, "postExpansionFn" -> postExpansionFn, "N" -> N];
+BuildTemplate[k_Integer, r_Real, core_List, postExpansionFn_, N_Integer] :=
+    Association["k" -> k, "r" -> r, "core" -> core, "postExpansionFn" -> postExpansionFn, "N" -> N];
 
 BaseTemplate[k_Integer, r_Real] :=
     With[{list = Symbol["x" <> ToString[#]] & /@ Range[(k^(Ceiling[r * 2] + 1)) -1, 0, -1]},
@@ -50,7 +50,7 @@ ValidTemplateCoreQ[templateCore_] :=
 (* Accessor functions *)
 
 TemplateCoreVars[template_Association] :=
-    TemplateCoreVars[kAryRuleTemplate[template]];
+    TemplateCoreVars[templateCore[template]];
 
 TemplateCoreVars[templateCore_List] :=
     With[{
@@ -64,7 +64,7 @@ r[t_Association] := t[["r"]];
 
 templateMod[t_Association] := t[["N"]];
 
-kAryRuleTemplate[t_Association] := t[["rawList"]];
+templateCore[t_Association] := t[["core"]];
 
 expansionFunction[t_Association] := t[["expansionFunction"]];
 

--- a/TemplateOperations/Expansion/ExpandTemplate.m
+++ b/TemplateOperations/Expansion/ExpandTemplate.m
@@ -19,7 +19,7 @@ ExpandTemplate[T_Template, i_Integer] := performs the ith expansion on template 
 Begin["`Private`"];
 
 SubstitutionRange[template_Association] :=
-    If[kAryRuleTemplate[template] === {},
+    If[templateCore[template] === {},
       {},
       Range[0, (template[["k"]]^Length[TemplateCoreVars[template]])-1]];
 
@@ -31,7 +31,7 @@ TransformationRules[variables_, substitution_] :=
 
 Expansion[template_Association, i_Integer] :=
     With[{variables = TemplateCoreVars[template]},
-      kAryRuleTemplate[template] /. TransformationRules[variables, Substitution[i, k[template], variables]]];
+      templateCore[template] /. TransformationRules[variables, Substitution[i, k[template], variables]]];
 
 (* Takes a list of 2 args Functions, fixes their firstArgument as firstArgument and composes a new one-arg Function. *)
 PartialComposition[postExpansionFns_List, firstArgument_] :=

--- a/TemplateOperations/Expansion/ExpandTemplate.m
+++ b/TemplateOperations/Expansion/ExpandTemplate.m
@@ -21,7 +21,7 @@ Begin["`Private`"];
 SubstitutionRange[template_Association] :=
     If[kAryRuleTemplate[template] === {},
       {},
-      Range[0, (template[["k"]]^Length[RuleTemplateVars[template]])-1]];
+      Range[0, (template[["k"]]^Length[TemplateCoreVars[template]])-1]];
 
 Substitution[i_, k_, variables_] :=
     Reverse[IntegerDigits[i, k, Length[variables]]];
@@ -30,7 +30,7 @@ TransformationRules[variables_, substitution_] :=
     MapThread[#1 -> #2 &, {variables, substitution}];
 
 Expansion[template_Association, i_Integer] :=
-    With[{variables = RuleTemplateVars[template]},
+    With[{variables = TemplateCoreVars[template]},
       kAryRuleTemplate[template] /. TransformationRules[variables, Substitution[i, k[template], variables]]];
 
 (* Takes a list of 2 args Functions, fixes their firstArgument as firstArgument and composes a new one-arg Function. *)

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -42,7 +42,7 @@ ReplacementRules[template1_Association, template2_Association]:=
       rawTemplate1 = RawTemplate[kAryRuleTemplate[template1]],
       rawTemplate2 = RawTemplate[kAryRuleTemplate[template2]],
       templateVars},
-      templateVars = SortBy[Union[Flatten[RuleTemplateVars[#] & /@ {rawTemplate1, rawTemplate2}, 1]], FromDigits[StringDrop[SymbolName[#],1]] &];
+      templateVars = SortBy[Union[Flatten[TemplateCoreVars[#] & /@ {rawTemplate1, rawTemplate2}, 1]], FromDigits[StringDrop[SymbolName[#],1]] &];
       If[ModIntersectionNeededQ[template1, template2],
         Quiet[Solve[EquationSystem[rawTemplate1, rawTemplate2], Reverse[templateVars], Modulus -> k]],
         Quiet[Solve[EquationSystem[rawTemplate1, rawTemplate2], templateVars]]]];

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -19,6 +19,10 @@ ReplacementRules[t1_List, t2_List, k_Integer]: Takes two templates t1 and t2, an
 
 TemplateIntersection::usage = "TemplateIntersection[template1_Association, template2_Association]: Receives two templates template1 and template2, and finds a third template that represents their intersection.";
 
+
+WinningPostExpansionFn::usage="remove";
+PostExpansionFnFight::usage="remove";
+
 Begin["`Private`"];
 
 ModTemplateQ[template_Association] :=
@@ -88,6 +92,9 @@ IntersectionFn[template1_Association, template2_Association] :=
 
 WinningPostExpansionFn[FilterOutOfRange, ModK] := FilterOutOfRange;
 WinningPostExpansionFn[ModK, FilterOutOfRange] := FilterOutOfRange;
+
+WinningPostExpansionFn[IdentityFn, expansion_] := expansion;
+WinningPostExpansionFn[expansion_, IdentityFn] := expansion;
 
 WinningPostExpansionFn[e1_, e2_] := e1;
 

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -39,8 +39,8 @@ EquationSystem[template1_List,template2_List]:=
 ReplacementRules[template1_Association, template2_Association]:=
     Module[{
       k = k[template1],
-      rawTemplate1 = RawTemplate[kAryRuleTemplate[template1]],
-      rawTemplate2 = RawTemplate[kAryRuleTemplate[template2]],
+      rawTemplate1 = RawTemplate[templateCore[template1]],
+      rawTemplate2 = RawTemplate[templateCore[template2]],
       templateVars},
       templateVars = SortBy[Union[Flatten[TemplateCoreVars[#] & /@ {rawTemplate1, rawTemplate2}, 1]], FromDigits[StringDrop[SymbolName[#],1]] &];
       If[ModIntersectionNeededQ[template1, template2],
@@ -70,15 +70,15 @@ ValueRestrictionIntersection[currentIntersectionResult_, valueRestrictions_, rep
 
 SimpleIntersection[replacementRules_, template1_Association, template2_Association] :=
     With[{
-      coreTemplate1 = RawTemplate[kAryRuleTemplate[template1]],
-      coreTemplate2 = RawTemplate[kAryRuleTemplate[template2]]},
+      coreTemplate1 = RawTemplate[templateCore[template1]],
+      coreTemplate2 = RawTemplate[templateCore[template2]]},
       If[replacementRules == {},
         {},
         First[Union[coreTemplate1 /.replacementRules, coreTemplate2 /. replacementRules]]]]
 
 ModIntersection[replacementRules_, template1_Association, template2_Association] :=
     With[{
-      coreTemplate1 = RawTemplate[kAryRuleTemplate[template1]]},
+      coreTemplate1 = RawTemplate[templateCore[template1]]},
       If[replacementRules == {},
         {},
         (*When a modular template returns 2 different sets of replacement rules, they both have equivalent expansions.
@@ -111,7 +111,7 @@ TemplateIntersection[template1_Association, template2_Association] :=
       expansion = PostExpansionFnFight[template1, template2],
       replacementRules = ReplacementRules[template1, template2],
       intersectionFn = IntersectionFn[template1, template2],
-      valueRestrictions = Join[ImprisonmentExpressions[kAryRuleTemplate[template1]], ImprisonmentExpressions[kAryRuleTemplate[template2]]],
+      valueRestrictions = Join[ImprisonmentExpressions[templateCore[template1]], ImprisonmentExpressions[templateCore[template2]]],
       intersectionResult},
 
       intersectionResult = ValueRestrictionIntersection[intersectionFn[replacementRules, template1, template2], valueRestrictions, replacementRules];

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -115,7 +115,9 @@ TemplateIntersection[template1_Association, template2_Association] :=
       intersectionResult},
 
       intersectionResult = ValueRestrictionIntersection[intersectionFn[replacementRules, template1, template2], valueRestrictions, replacementRules];
-      BuildTemplate[k, r, intersectionResult, expansion]];
+      If[ValidTemplateCoreQ[intersectionResult],
+        BuildTemplate[k, r, intersectionResult, expansion],
+        BuildTemplate[k, r, {}, expansion]]];
 
 (* The intersection between two sets of templates is given by the outer product of the intersection over the sets. *)
 TemplateIntersection[x_List, y_List] :=

--- a/Tests/CATemplate.m
+++ b/Tests/CATemplate.m
@@ -74,6 +74,20 @@ ValidTemplateCoreQReport = TestReport[{
 
 PrintTestResults[ValidTemplateCoreQReport];
 
+Print["TemplateCoreVars"];
+
+TemplateCoreVarsReport = TestReport[{
+  VerificationTest[TemplateCoreVars[{1,2,3,4}] === {}],
+  VerificationTest[TemplateCoreVars[{1,2,3,x0}] === {x0}],
+  VerificationTest[TemplateCoreVars[{x3,2,3,x0}] === {x0, x3}],
+  VerificationTest[TemplateCoreVars[{y3,2,3,y0}] === {y0, y3}],
+  VerificationTest[TemplateCoreVars[{x3 \[Element] {1,0},2,3,x0}] === {x0, x3}],
+  VerificationTest[TemplateCoreVars[OldBaseTemplate[]] === {x0, x1, x2, x3, x4, x5, x6, x7}],
+  VerificationTest[TemplateCoreVars[BaseTemplate[2, 1.0]] === {x0, x1, x2, x3, x4, x5, x6, x7}]
+}];
+
+PrintTestResults[TemplateCoreVarsReport];
+
 Print["accessorFns"];
 
 accessorFnsReport = TestReport[{

--- a/Tests/CATemplate.m
+++ b/Tests/CATemplate.m
@@ -7,23 +7,23 @@ Print["BuildTemplate"];
 buildTemplateReport = TestReport[{
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "rawList" -> {x7, x6, x5, x4, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn|>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "core" -> {x7, x6, x5, x4, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn|>},
       BuildTemplate[2, 1.0, {x7, x6, x5, x4, x3, x2, x1, x0}] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "rawList" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> IdentityFn|>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "core" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> IdentityFn|>},
       BuildTemplate[2, 1.0, {x7, 1, x5, x4, 1, x2, x1, 0}] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "rawList" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2] |>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "core" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2] |>},
       BuildTemplate[3, 1.5, {x7, 1, x5, x4, 1, x2, x1, 0}, Function[{x,y}, 2]] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "rawList" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2], "N" -> 2|>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "core" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2], "N" -> 2|>},
       BuildTemplate[3, 1.5, {x7, 1, x5, x4, 1, x2, x1, 0}, Function[{x,y}, 2], 2] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "rawList" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2], "N" -> 3|>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "core" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2], "N" -> 3|>},
       BuildTemplate[3, 1.5, {x7, 1, x5, x4, 1, x2, x1, 0}, Function[{x,y}, 2], 3] === expectedTemplate]]}];
 
 PrintTestResults[buildTemplateReport];
@@ -96,7 +96,7 @@ accessorFnsReport = TestReport[{
   VerificationTest[r[BaseTemplate[2, 1.0]] === 1.0],
   VerificationTest[r[BaseTemplate[2, 2.0]] === 2.0],
   VerificationTest[postExpansionFn[BuildTemplate[2, 2.0, {}, FilterOutOfRange]] === FilterOutOfRange],
-  VerificationTest[kAryRuleTemplate[BaseTemplate[2, 1.0]] === {x7,x6,x5,x4,x3,x2,x1,x0}]
+  VerificationTest[templateCore[BaseTemplate[2, 1.0]] === {x7,x6,x5,x4,x3,x2,x1,x0}]
 }];
 
 PrintTestResults[accessorFnsReport];

--- a/Tests/CATemplate.m
+++ b/Tests/CATemplate.m
@@ -28,6 +28,8 @@ buildTemplateReport = TestReport[{
 
 PrintTestResults[buildTemplateReport];
 
+Print["BaseTemplate"];
+
 baseTemplateReport = TestReport[{
   VerificationTest[
     With[
@@ -55,6 +57,24 @@ baseTemplateReport = TestReport[{
       BaseTemplate[2, 2.0] === expectedTemplate]]}];
 
 PrintTestResults[baseTemplateReport];
+
+Print["ValidTemplateCoreQ"];
+
+ValidTemplateCoreQReport = TestReport[{
+  VerificationTest[ValidTemplateCoreQ[{1,2,3,4,5}] === True],
+  VerificationTest[ValidTemplateCoreQ[OldBaseTemplate[]] === True],
+  VerificationTest[ValidTemplateCoreQ[{1x2, 2x1, 3x0}] === True],
+  (* We can have fractions as long as they are multiplying a variable *)
+  VerificationTest[ValidTemplateCoreQ[{1,2,3,4,5/2x1}] === True],
+  VerificationTest[ValidTemplateCoreQ[{1,2,3-x2,4+x1,5/2x1}] === True],
+  VerificationTest[ValidTemplateCoreQ[{1/2,2,3,4,5}] === False],
+  VerificationTest[ValidTemplateCoreQ[{1,2/4,3-x2,4+x1,5/2x1}] === False],
+  VerificationTest[ValidTemplateCoreQ[{1,1.0,3-x2,4,5}] === False],
+  VerificationTest[ValidTemplateCoreQ[{1,2,"bla",4,5}] === False]}];
+
+PrintTestResults[ValidTemplateCoreQReport];
+
+Print["accessorFns"];
 
 accessorFnsReport = TestReport[{
   VerificationTest[k[BaseTemplate[2, 1.0]] === 2],

--- a/Tests/TemplateGeneration/ColorBlindTemplate.m
+++ b/Tests/TemplateGeneration/ColorBlindTemplate.m
@@ -13,7 +13,7 @@ TestAllPermutations[ruleTable_, k_] :=
     And @@ (TestTable[ruleTable, #, k] & /@ PossibleStateReplacements[k]);
 
 report = TestReport[{
-  VerificationTest[ColorBlindTemplate[2][["rawList"]] === SymmetricTemplate[BWTransform, 8][[1]][["rawList"]]],
+  VerificationTest[templateCore[ColorBlindTemplate[2]] === templateCore[SymmetricTemplate[BWTransform, 8][[1]]]],
   VerificationTest[And @@ (TestAllPermutations[#, 3] & /@ ExpandTemplate[ColorBlindTemplate[3]]) === True]
 }];
 

--- a/Tests/TemplateGeneration/StateConservingTemplate.m
+++ b/Tests/TemplateGeneration/StateConservingTemplate.m
@@ -14,9 +14,9 @@ report = TestReport[{
   VerificationTest[
     Sort[FromDigits[#, 2] & /@ ExpandTemplate[ModNStateConservingTemplate[2]]] == {132, 150, 170, 184, 204, 222, 226, 240}],
   VerificationTest[
-    PreservesIndexVariableDualityQ[ModNStateConservingTemplate[2][["rawList"]]]],
+    PreservesIndexVariableDualityQ[ModNStateConservingTemplate[2][["core"]]]],
   VerificationTest[
-    PreservesIndexVariableDualityQ[ModNStateConservingTemplate[3][["rawList"]]]]
+    PreservesIndexVariableDualityQ[ModNStateConservingTemplate[3][["core"]]]]
 }];
 
 PrintTestResults[report];

--- a/Tests/TemplateGeneration/TotalisticTemplate.m
+++ b/Tests/TemplateGeneration/TotalisticTemplate.m
@@ -8,27 +8,27 @@
 report = TestReport[{
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "rawList" -> {x7, x3, x3, x1, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "core" -> {x7, x3, x3, x1, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       TotalisticTemplate[2, 1.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 2.0, "rawList" -> {x31, x15, x15, x7, x15, x7, x7, x3, x15, x7, x7, x3, x7, x3, x3, x1, x15, x7, x7, x3, x7, x3, x3, x1, x7, x3, x3, x1, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 2.0, "core" -> {x31, x15, x15, x7, x15, x7, x7, x3, x15, x7, x7, x3, x7, x3, x3, x1, x15, x7, x7, x3, x7, x3, x3, x1, x7, x3, x3, x1, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       TotalisticTemplate[2, 2.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.0, "rawList" -> {x26, x17, x8, x17, x8, x5, x8, x5, x2, x17, x8, x5, x8, x5, x2, x5, x2, x1, x8, x5, x2, x5, x2, x1, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.0, "core" -> {x26, x17, x8, x17, x8, x5, x8, x5, x2, x17, x8, x5, x8, x5, x2, x5, x2, x1, x8, x5, x2, x5, x2, x1, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       TotalisticTemplate[3, 1.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "rawList" -> {x7, x3, x5, x1, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "core" -> {x7, x3, x5, x1, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       OuterTotalisticTemplate[2, 1.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 2.0, "rawList" -> {x31, x15, x15, x7, x27, x11, x11, x3, x15, x7, x7, x5, x11, x3, x3, x1, x15, x7, x7, x5, x11, x3, x3, x1, x7, x5, x5, x4, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 2.0, "core" -> {x31, x15, x15, x7, x27, x11, x11, x3, x15, x7, x7, x5, x11, x3, x3, x1, x15, x7, x7, x5, x11, x3, x3, x1, x7, x5, x5, x4, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       OuterTotalisticTemplate[2, 2.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.0, "rawList" -> {x26, x17, x8, x23, x14, x5, x20, x11, x2, x17, x8, x7, x14, x5, x4, x11, x2, x1, x8, x7, x6, x5, x4, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.0, "core" -> {x26, x17, x8, x23, x14, x5, x20, x11, x2, x17, x8, x7, x14, x5, x4, x11, x2, x1, x8, x7, x6, x5, x4, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       OuterTotalisticTemplate[3, 1.0] === expectedTemplate]]}];
 
 PrintTestResults[report];


### PR DESCRIPTION
We finally have green unit and integration tests, meaning both `intersection` and `expansion`  operations are working 100% for every template we generate with k=2 and r=1.0. 
This was achieved with the introduction of `PostExpansionFnFight`, which takes care of deciding which `postExpansionFn` should win whenever an intersection happens.

Merging this PR will give us what is problably version 1.0.0-RC1 of `CATemplates` 
:tada: :tada: :tada: 

BONUS: Refactors and renames old functions from the `Basic` namespace and moves them to the new `CATemplate` namespace.
- RuleTemplateVars -> TemplateCoreVars
- ValidTemplateQ -> ValidTempalteCoreQ

Next steps: 
- [ ] find out some "generativish" way to test greater spaces.
- [x] formalize `templateCore` in place of `rawList` and `kAryRuleTemplate`, which are just awful names. (Done in #58)
- [ ] kill the `Basic` legacy namespace, moving coherent stuff to `CATemplate`, and removing legacy unused code.

@PPBO and @zorandir can you guys take a look? :smile: 
