### PR TITLE
Renames `rawList` and `kAryRuleTemplate`

### DIFF
--- a/Basic.wl
+++ b/Basic.wl
@@ -60,7 +60,7 @@ OldBaseTemplate[k_Integer: 2, r_: 1] :=
 
 (*Deprecated!!*)
 RuleTemplateVars[ruletemplate_Association] :=
-    RuleTemplateVars[ruletemplate[["rawList"]]];
+    RuleTemplateVars[ruletemplate[["core"]]];
 (*Deprecated!!*)
 RuleTemplateVars[ruletemplate_] :=
   SortBy[Union[Cases[ruletemplate, _Symbol, Infinity]], FromDigits[StringDrop[SymbolName[#],1]]&]

--- a/CATemplate.wl
+++ b/CATemplate.wl
@@ -1,11 +1,11 @@
 BeginPackage["CATemplates`CATemplate`", {"CATemplates`TemplateOperations`Expansion`PostExpansionFn`IdentityFn`"}];
 
 BuildTemplate::usage=
-    "BuildTemplate[k_Integer, r_Real, rawList_List, expansion_Function]
-  Builds a template that represents the subspace of the CA space given by k and r, described by the variables in <rawList>.
+    "BuildTemplate[k_Integer, r_Real, core_List, expansion_Function]
+  Builds a template that represents the subspace of the CA space given by k and r, described by the variables in <core>.
   <expansion> is the function used by ExpandTemplate to expand the built template.
-BuildTemplate[k_Integer, r_Real, rawList_List, expansion_Function, N_Integer]
-  <N> is the value of modulus used by the template generator to create <rawList>.";
+BuildTemplate[k_Integer, r_Real, core_List, expansion_Function, N_Integer]
+  <N> is the value of modulus used by the template generator to create <core>.";
 
 BaseTemplate::usage="BaseTemplate[k_Integer, r_Real] := Gives the base template for the space of radius r k-ary rules.";
 
@@ -17,7 +17,7 @@ k::usage="k[t_] = Gets the number of possible states (k) for cells of the space 
 
 r::usage="r[t_] = Gets the radius (r) of the family represented by template t.";
 
-kAryRuleTemplate::usage="kAryRuleTemplate[t_] = Gets the kAryRuleTemplate which represents a subset of the base t (including template variables).";
+templateCore::usage="templateCore[t_] = Gets the core of template t (list of variables + fixed positions).";
 
 expansionFunction::usage="expansionFunction[t_] = Gets the expansion function used by template t.";
 
@@ -29,14 +29,14 @@ Begin["`Private`"];
 
 (* Builder functions *)
 
-BuildTemplate[k_Integer, r_Real, rawList_List] :=
-    Association["k" -> k, "r" -> r, "rawList" -> rawList, "postExpansionFn" -> IdentityFn];
+BuildTemplate[k_Integer, r_Real, core_List] :=
+    Association["k" -> k, "r" -> r, "core" -> core, "postExpansionFn" -> IdentityFn];
 
-BuildTemplate[k_Integer, r_Real, rawList_List, postExpansionFn_] :=
-    Association["k" -> k, "r" -> r, "rawList" -> rawList, "postExpansionFn" -> postExpansionFn];
+BuildTemplate[k_Integer, r_Real, core_List, postExpansionFn_] :=
+    Association["k" -> k, "r" -> r, "core" -> core, "postExpansionFn" -> postExpansionFn];
 
-BuildTemplate[k_Integer, r_Real, rawList_List, postExpansionFn_, N_Integer] :=
-    Association["k" -> k, "r" -> r, "rawList" -> rawList, "postExpansionFn" -> postExpansionFn, "N" -> N];
+BuildTemplate[k_Integer, r_Real, core_List, postExpansionFn_, N_Integer] :=
+    Association["k" -> k, "r" -> r, "core" -> core, "postExpansionFn" -> postExpansionFn, "N" -> N];
 
 BaseTemplate[k_Integer, r_Real] :=
     With[{list = Symbol["x" <> ToString[#]] & /@ Range[(k^(Ceiling[r * 2] + 1)) -1, 0, -1]},
@@ -50,7 +50,7 @@ ValidTemplateCoreQ[templateCore_] :=
 (* Accessor functions *)
 
 TemplateCoreVars[template_Association] :=
-    TemplateCoreVars[kAryRuleTemplate[template]];
+    TemplateCoreVars[templateCore[template]];
 
 TemplateCoreVars[templateCore_List] :=
     With[{
@@ -64,7 +64,7 @@ r[t_Association] := t[["r"]];
 
 templateMod[t_Association] := t[["N"]];
 
-kAryRuleTemplate[t_Association] := t[["rawList"]];
+templateCore[t_Association] := t[["core"]];
 
 expansionFunction[t_Association] := t[["expansionFunction"]];
 

--- a/TemplateOperations/Expansion/ExpandTemplate.m
+++ b/TemplateOperations/Expansion/ExpandTemplate.m
@@ -19,7 +19,7 @@ ExpandTemplate[T_Template, i_Integer] := performs the ith expansion on template 
 Begin["`Private`"];
 
 SubstitutionRange[template_Association] :=
-    If[kAryRuleTemplate[template] === {},
+    If[templateCore[template] === {},
       {},
       Range[0, (template[["k"]]^Length[TemplateCoreVars[template]])-1]];
 
@@ -31,7 +31,7 @@ TransformationRules[variables_, substitution_] :=
 
 Expansion[template_Association, i_Integer] :=
     With[{variables = TemplateCoreVars[template]},
-      kAryRuleTemplate[template] /. TransformationRules[variables, Substitution[i, k[template], variables]]];
+      templateCore[template] /. TransformationRules[variables, Substitution[i, k[template], variables]]];
 
 (* Takes a list of 2 args Functions, fixes their firstArgument as firstArgument and composes a new one-arg Function. *)
 PartialComposition[postExpansionFns_List, firstArgument_] :=

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -39,8 +39,8 @@ EquationSystem[template1_List,template2_List]:=
 ReplacementRules[template1_Association, template2_Association]:=
     Module[{
       k = k[template1],
-      rawTemplate1 = RawTemplate[kAryRuleTemplate[template1]],
-      rawTemplate2 = RawTemplate[kAryRuleTemplate[template2]],
+      rawTemplate1 = RawTemplate[templateCore[template1]],
+      rawTemplate2 = RawTemplate[templateCore[template2]],
       templateVars},
       templateVars = SortBy[Union[Flatten[TemplateCoreVars[#] & /@ {rawTemplate1, rawTemplate2}, 1]], FromDigits[StringDrop[SymbolName[#],1]] &];
       If[ModIntersectionNeededQ[template1, template2],
@@ -70,15 +70,15 @@ ValueRestrictionIntersection[currentIntersectionResult_, valueRestrictions_, rep
 
 SimpleIntersection[replacementRules_, template1_Association, template2_Association] :=
     With[{
-      coreTemplate1 = RawTemplate[kAryRuleTemplate[template1]],
-      coreTemplate2 = RawTemplate[kAryRuleTemplate[template2]]},
+      coreTemplate1 = RawTemplate[templateCore[template1]],
+      coreTemplate2 = RawTemplate[templateCore[template2]]},
       If[replacementRules == {},
         {},
         First[Union[coreTemplate1 /.replacementRules, coreTemplate2 /. replacementRules]]]]
 
 ModIntersection[replacementRules_, template1_Association, template2_Association] :=
     With[{
-      coreTemplate1 = RawTemplate[kAryRuleTemplate[template1]]},
+      coreTemplate1 = RawTemplate[templateCore[template1]]},
       If[replacementRules == {},
         {},
         (*When a modular template returns 2 different sets of replacement rules, they both have equivalent expansions.
@@ -111,7 +111,7 @@ TemplateIntersection[template1_Association, template2_Association] :=
       expansion = PostExpansionFnFight[template1, template2],
       replacementRules = ReplacementRules[template1, template2],
       intersectionFn = IntersectionFn[template1, template2],
-      valueRestrictions = Join[ImprisonmentExpressions[kAryRuleTemplate[template1]], ImprisonmentExpressions[kAryRuleTemplate[template2]]],
+      valueRestrictions = Join[ImprisonmentExpressions[templateCore[template1]], ImprisonmentExpressions[templateCore[template2]]],
       intersectionResult},
 
       intersectionResult = ValueRestrictionIntersection[intersectionFn[replacementRules, template1, template2], valueRestrictions, replacementRules];

--- a/Tests/CATemplate.m
+++ b/Tests/CATemplate.m
@@ -7,23 +7,23 @@ Print["BuildTemplate"];
 buildTemplateReport = TestReport[{
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "rawList" -> {x7, x6, x5, x4, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn|>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "core" -> {x7, x6, x5, x4, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn|>},
       BuildTemplate[2, 1.0, {x7, x6, x5, x4, x3, x2, x1, x0}] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "rawList" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> IdentityFn|>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "core" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> IdentityFn|>},
       BuildTemplate[2, 1.0, {x7, 1, x5, x4, 1, x2, x1, 0}] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "rawList" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2] |>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "core" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2] |>},
       BuildTemplate[3, 1.5, {x7, 1, x5, x4, 1, x2, x1, 0}, Function[{x,y}, 2]] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "rawList" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2], "N" -> 2|>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "core" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2], "N" -> 2|>},
       BuildTemplate[3, 1.5, {x7, 1, x5, x4, 1, x2, x1, 0}, Function[{x,y}, 2], 2] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "rawList" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2], "N" -> 3|>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.5, "core" -> {x7, 1, x5, x4, 1, x2, x1, 0}, "postExpansionFn" -> Function[{x,y}, 2], "N" -> 3|>},
       BuildTemplate[3, 1.5, {x7, 1, x5, x4, 1, x2, x1, 0}, Function[{x,y}, 2], 3] === expectedTemplate]]}];
 
 PrintTestResults[buildTemplateReport];
@@ -96,7 +96,7 @@ accessorFnsReport = TestReport[{
   VerificationTest[r[BaseTemplate[2, 1.0]] === 1.0],
   VerificationTest[r[BaseTemplate[2, 2.0]] === 2.0],
   VerificationTest[postExpansionFn[BuildTemplate[2, 2.0, {}, FilterOutOfRange]] === FilterOutOfRange],
-  VerificationTest[kAryRuleTemplate[BaseTemplate[2, 1.0]] === {x7,x6,x5,x4,x3,x2,x1,x0}]
+  VerificationTest[templateCore[BaseTemplate[2, 1.0]] === {x7,x6,x5,x4,x3,x2,x1,x0}]
 }];
 
 PrintTestResults[accessorFnsReport];

--- a/Tests/TemplateGeneration/ColorBlindTemplate.m
+++ b/Tests/TemplateGeneration/ColorBlindTemplate.m
@@ -13,7 +13,7 @@ TestAllPermutations[ruleTable_, k_] :=
     And @@ (TestTable[ruleTable, #, k] & /@ PossibleStateReplacements[k]);
 
 report = TestReport[{
-  VerificationTest[ColorBlindTemplate[2][["rawList"]] === SymmetricTemplate[BWTransform, 8][[1]][["rawList"]]],
+  VerificationTest[templateCore[ColorBlindTemplate[2]] === templateCore[SymmetricTemplate[BWTransform, 8][[1]]]],
   VerificationTest[And @@ (TestAllPermutations[#, 3] & /@ ExpandTemplate[ColorBlindTemplate[3]]) === True]
 }];
 

--- a/Tests/TemplateGeneration/StateConservingTemplate.m
+++ b/Tests/TemplateGeneration/StateConservingTemplate.m
@@ -14,9 +14,9 @@ report = TestReport[{
   VerificationTest[
     Sort[FromDigits[#, 2] & /@ ExpandTemplate[ModNStateConservingTemplate[2]]] == {132, 150, 170, 184, 204, 222, 226, 240}],
   VerificationTest[
-    PreservesIndexVariableDualityQ[ModNStateConservingTemplate[2][["rawList"]]]],
+    PreservesIndexVariableDualityQ[ModNStateConservingTemplate[2][["core"]]]],
   VerificationTest[
-    PreservesIndexVariableDualityQ[ModNStateConservingTemplate[3][["rawList"]]]]
+    PreservesIndexVariableDualityQ[ModNStateConservingTemplate[3][["core"]]]]
 }];
 
 PrintTestResults[report];

--- a/Tests/TemplateGeneration/TotalisticTemplate.m
+++ b/Tests/TemplateGeneration/TotalisticTemplate.m
@@ -8,27 +8,27 @@
 report = TestReport[{
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "rawList" -> {x7, x3, x3, x1, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "core" -> {x7, x3, x3, x1, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       TotalisticTemplate[2, 1.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 2.0, "rawList" -> {x31, x15, x15, x7, x15, x7, x7, x3, x15, x7, x7, x3, x7, x3, x3, x1, x15, x7, x7, x3, x7, x3, x3, x1, x7, x3, x3, x1, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 2.0, "core" -> {x31, x15, x15, x7, x15, x7, x7, x3, x15, x7, x7, x3, x7, x3, x3, x1, x15, x7, x7, x3, x7, x3, x3, x1, x7, x3, x3, x1, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       TotalisticTemplate[2, 2.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.0, "rawList" -> {x26, x17, x8, x17, x8, x5, x8, x5, x2, x17, x8, x5, x8, x5, x2, x5, x2, x1, x8, x5, x2, x5, x2, x1, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.0, "core" -> {x26, x17, x8, x17, x8, x5, x8, x5, x2, x17, x8, x5, x8, x5, x2, x5, x2, x1, x8, x5, x2, x5, x2, x1, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       TotalisticTemplate[3, 1.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "rawList" -> {x7, x3, x5, x1, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 1.0, "core" -> {x7, x3, x5, x1, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       OuterTotalisticTemplate[2, 1.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 2, "r" -> 2.0, "rawList" -> {x31, x15, x15, x7, x27, x11, x11, x3, x15, x7, x7, x5, x11, x3, x3, x1, x15, x7, x7, x5, x11, x3, x3, x1, x7, x5, x5, x4, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 2, "r" -> 2.0, "core" -> {x31, x15, x15, x7, x27, x11, x11, x3, x15, x7, x7, x5, x11, x3, x3, x1, x15, x7, x7, x5, x11, x3, x3, x1, x7, x5, x5, x4, x3, x1, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       OuterTotalisticTemplate[2, 2.0] === expectedTemplate]],
   VerificationTest[
     With[
-      {expectedTemplate = <|"k" -> 3, "r" -> 1.0, "rawList" -> {x26, x17, x8, x23, x14, x5, x20, x11, x2, x17, x8, x7, x14, x5, x4, x11, x2, x1, x8, x7, x6, x5, x4, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
+      {expectedTemplate = <|"k" -> 3, "r" -> 1.0, "core" -> {x26, x17, x8, x23, x14, x5, x20, x11, x2, x17, x8, x7, x14, x5, x4, x11, x2, x1, x8, x7, x6, x5, x4, x3, x2, x1, x0}, "postExpansionFn" -> IdentityFn |>},
       OuterTotalisticTemplate[3, 1.0] === expectedTemplate]]}];
 
 PrintTestResults[report];


### PR DESCRIPTION
...  to `core` and `templateCore`, respectively.
