### PR TITLE
Fix templateIntersection and ColorBlindTemplate

### DIFF
--- a/TemplateGeneration/ColorBlindTemplate.wl
+++ b/TemplateGeneration/ColorBlindTemplate.wl
@@ -5,6 +5,7 @@ BeginPackage["CATemplates`TemplateGeneration`ColorBlindTemplate`",
     "CATemplates`CA`",
     "CATemplates`CATemplate`",
     "CATemplates`TemplateOperations`Intersection`TemplateIntersection`",
+    "CATemplates`TemplateOperations`Expansion`PostExpansionFn`FilterNotAllowed`",
     "CATemplates`TemplateOperations`Expansion`PostExpansionFn`ModK`"
   }];
 
@@ -79,7 +80,7 @@ ColorBlindTemplate[permutation_List, k_Integer: 2, r_Real: 1.0] :=
       neighbourhoods = Reverse[AllNeighbourhoods[k, r]];
       nbEqClasses = PartitionByPermutation[neighbourhoods, permutation];
       replacementRules = Join[InvariantReplacementRules[nbEqClasses, permutation, k], VariantReplacementRules[nbEqClasses, permutation, k]];
-      BuildTemplate[k, r, BaseTemplateCore[k, r] /. replacementRules, ModK]
+      BuildTemplate[k, r, BaseTemplateCore[k, r] /. replacementRules, {FilterNotAllowed, ModK}]
     ];
 
 End[];

--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -28,7 +28,9 @@ Begin["`Private`"];
 
 ModTemplateQ[template_Association] :=
     Or[postExpansionFn[template] === ModK,
-       postExpansionFn[template] === TemplateMod];
+       postExpansionFn[template] === TemplateMod,
+       MemberQ[postExpansionFn[template], ModK],
+       MemberQ[postExpansionFn[template], TemplateMod]];
 
 ModIntersectionNeededQ[template1_Association, template2_Association] :=
     And[ModTemplateQ[template1],

--- a/Tests/TemplateOperations/Intersection/TemplateIntersection.m
+++ b/Tests/TemplateOperations/Intersection/TemplateIntersection.m
@@ -133,6 +133,16 @@ modReport = TestReport[{
         i1 = TemplateIntersection[t1, t2],
         i2 = TemplateIntersection[t1, t3],
         result = BuildTemplate[3, 1.0, {1, 0}, ModK]},
+        TemplateIntersection[i1, i2] === result]]],
+  VerificationTest[(*Should work even if ModK is in a list of postExpansionFns*)
+    With[{
+      t1 = BuildTemplate[3, 1.0, {x1, x0}, {FilterNotAllowed, ModK}],
+      t2 = BuildTemplate[3, 1.0, {4, x0}, {FilterNotAllowed, ModK}],
+      t3 = BuildTemplate[3, 1.0, {x1, 0}, {FilterNotAllowed, ModK}]},
+      With[{
+        i1 = TemplateIntersection[t1, t2],
+        i2 = TemplateIntersection[t1, t3],
+        result = BuildTemplate[3, 1.0, {1, 0}, {FilterNotAllowed, ModK}]},
         TemplateIntersection[i1, i2] === result]]]}];
 
 PrintReport[modReport];


### PR DESCRIPTION
Two bugs were fixed here:

1 - TemplateIntersection was not using the `Module->k` option on Solve when `ModK` or `TemplateMod` `postExpansionFns` were specified together with other functions on a list.

2 - ColorblindTemplate uses variable restriction expressions when k >= 4, so it needs `{FilterNotAlowed, ModK}` as its postExpansionFn.

These fixes are a first step in the direction of solving #21.