### PR TITLE
FilterOutOfRange should always win

### DIFF
--- a/TemplateOperations/Intersection/TemplateIntersection.wl
+++ b/TemplateOperations/Intersection/TemplateIntersection.wl
@@ -96,8 +96,8 @@ IntersectionFn[template1_Association, template2_Association] :=
       ModIntersection,
       SimpleIntersection];
 
-WinningPostExpansionFn[FilterOutOfRange, ModK] := FilterOutOfRange;
-WinningPostExpansionFn[ModK, FilterOutOfRange] := FilterOutOfRange;
+WinningPostExpansionFn[FilterOutOfRange, _] := FilterOutOfRange;
+WinningPostExpansionFn[_, FilterOutOfRange] := FilterOutOfRange;
 
 WinningPostExpansionFn[IdentityFn, expansion_] := expansion;
 WinningPostExpansionFn[expansion_, IdentityFn] := expansion;


### PR DESCRIPTION
`TestIntersection[ColorBlindTemplate[2, 1.0],  StateConservingTemplate[2, 1.0]]` was failing because of this.